### PR TITLE
Add AutomationStopped event with exit code reporting

### DIFF
--- a/src/G4.Api/Abstractions/IAutomationClient.cs
+++ b/src/G4.Api/Abstractions/IAutomationClient.cs
@@ -42,6 +42,11 @@ namespace G4.Api.Abstractions
         event EventHandler<AutomationEventArgs> AutomationStatusChanged;
 
         /// <summary>
+        /// Occurs when the automation process has stopped, providing the exit code of the operation.
+        /// </summary>
+        event EventHandler<int> AutomationStopped;
+
+        /// <summary>
         /// Occurs after a job has been invoked.
         /// </summary>
         event EventHandler<JobEventArgs> JobInvoked;

--- a/src/G4.Api/Clients/AutomationClient.cs
+++ b/src/G4.Api/Clients/AutomationClient.cs
@@ -48,6 +48,9 @@ namespace G4.Api.Clients
         public event EventHandler<AutomationEventArgs> AutomationStatusChanged;
 
         /// <inheritdoc />
+        public event EventHandler<int> AutomationStopped;
+
+        /// <inheritdoc />
         public event EventHandler<JobEventArgs> JobInvoked;
 
         /// <inheritdoc />
@@ -138,6 +141,10 @@ namespace G4.Api.Clients
         /// <inheritdoc />
         public int StopAutomation(string automationId)
         {
+            // Initialize the exit code to 0, indicating success by default.
+            // This will be updated to 1 if any errors occur during the stop process.
+            var exitCode = 0;
+
             try
             {
                 // Attempt to retrieve the CancellationTokenSource associated with the automation ID
@@ -184,16 +191,20 @@ namespace G4.Api.Clients
                         driver?.Dispose();
                     }
                 }
-
-                // Signal successful termination
-                return 0;
             }
             catch
             {
                 // Any failure (lookup, driver close, dispose, etc.)
                 // results in a non-zero exit code
-                return 1;
+                exitCode = 1;
             }
+            finally
+            {
+                AutomationStopped?.Invoke(sender: this, e: exitCode);
+            }
+
+            // Return the exit code indicating the result of the stop operation
+            return exitCode;
         }
 
         // Invokes automation tasks based on the provided array of queue models with a specified maximum degree of parallelism.


### PR DESCRIPTION
Introduce AutomationStopped event to IAutomationClient and AutomationClient, triggered when automation stops and providing the exit code. Update StopAutomation to determine and return the exit code, and invoke the event regardless of success or failure.