### PR TITLE
Update G4.* package versions and add test runner config

### DIFF
--- a/src/G4.Api/G4.Api.csproj
+++ b/src/G4.Api/G4.Api.csproj
@@ -30,11 +30,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Cache" Version="2026.3.19.58" />
-		<PackageReference Include="G4.CredentialsManager" Version="2026.3.19.58" />
-		<PackageReference Include="G4.Plugins" Version="2026.3.19.58" />
-		<PackageReference Include="G4.Plugins.Common" Version="2026.1.20.120" />
-		<PackageReference Include="G4.Plugins.Ui" Version="2026.1.20.120" />
+		<PackageReference Include="G4.Cache" Version="2026.3.19.59" />
+		<PackageReference Include="G4.CredentialsManager" Version="2026.3.19.59" />
+		<PackageReference Include="G4.Plugins" Version="2026.3.19.59" />
+		<PackageReference Include="G4.Plugins.Common" Version="2026.3.20.123" />
+		<PackageReference Include="G4.Plugins.Ui" Version="2026.3.20.123" />
 	</ItemGroup>
 
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
Updated G4.Cache, G4.CredentialsManager, and G4.Plugins to version 2026.3.19.59, and G4.Plugins.Common and G4.Plugins.Ui to 2026.3.20.123 in G4.Api.csproj. Added global.json to specify Microsoft.Testing.Platform as the test runner.