### PR TITLE
Update NuGet package versions and add Google plugin

### DIFF
--- a/src/G4.Api/G4.Api.csproj
+++ b/src/G4.Api/G4.Api.csproj
@@ -30,11 +30,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Cache" Version="2026.4.6.60" />
-		<PackageReference Include="G4.CredentialsManager" Version="2026.4.6.60" />
-		<PackageReference Include="G4.Plugins" Version="2026.4.6.60" />
-		<PackageReference Include="G4.Plugins.Common" Version="2026.3.20.123" />
-		<PackageReference Include="G4.Plugins.Ui" Version="2026.3.20.123" />
+		<PackageReference Include="G4.Cache" Version="2026.4.12.61" />
+		<PackageReference Include="G4.CredentialsManager" Version="2026.4.12.61" />
+		<PackageReference Include="G4.Plugins" Version="2026.4.12.61" />
+		<PackageReference Include="G4.Plugins.Common" Version="2026.4.13.124" />
+		<PackageReference Include="G4.Plugins.Google" Version="2026.4.13.124" />
+		<PackageReference Include="G4.Plugins.Ui" Version="2026.4.13.124" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgraded G4.Cache, G4.CredentialsManager, and G4.Plugins to 2026.4.12.61. Updated G4.Plugins.Common and G4.Plugins.Ui to 2026.4.13.124. Added new package reference for G4.Plugins.Google version 2026.4.13.124.