### PR TITLE
Update NuGet package versions across projects

### DIFF
--- a/src/G4.Api/G4.Api.csproj
+++ b/src/G4.Api/G4.Api.csproj
@@ -30,12 +30,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Cache" Version="2026.4.12.61" />
-		<PackageReference Include="G4.CredentialsManager" Version="2026.4.12.61" />
-		<PackageReference Include="G4.Plugins" Version="2026.4.12.61" />
-		<PackageReference Include="G4.Plugins.Common" Version="2026.4.13.124" />
-		<PackageReference Include="G4.Plugins.Google" Version="2026.4.13.124" />
-		<PackageReference Include="G4.Plugins.Ui" Version="2026.4.13.124" />
+		<PackageReference Include="G4.Cache" Version="2026.4.22.64" />
+		<PackageReference Include="G4.CredentialsManager" Version="2026.4.22.64" />
+		<PackageReference Include="G4.Plugins" Version="2026.4.22.64" />
+		<PackageReference Include="G4.Plugins.Common" Version="2026.4.22.127" />
+		<PackageReference Include="G4.Plugins.Google" Version="2026.4.22.127" />
+		<PackageReference Include="G4.Plugins.Ui" Version="2026.4.22.127" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -32,11 +32,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.5" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.7" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-		<PackageReference Include="coverlet.collector" Version="8.0.1">
+		<PackageReference Include="coverlet.collector" Version="10.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -32,16 +32,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.5" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.7" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-		<PackageReference Include="coverlet.collector" Version="8.0.1">
+		<PackageReference Include="coverlet.collector" Version="10.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.5" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Upgraded multiple NuGet dependencies in G4.Api, G4.IntegrationTests, and G4.UnitTests projects. Packages updated include G4.Cache, G4.CredentialsManager, G4.Plugins (and related), Microsoft.AspNetCore.MiddlewareAnalysis, Microsoft.NET.Test.Sdk, coverlet.collector, and System.Configuration.ConfigurationManager. This ensures compatibility with the latest features and bug fixes.