### PR TITLE
Update NuGet package versions in project files

### DIFF
--- a/src/G4.Api/G4.Api.csproj
+++ b/src/G4.Api/G4.Api.csproj
@@ -30,12 +30,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Cache" Version="2026.4.22.64" />
-		<PackageReference Include="G4.CredentialsManager" Version="2026.4.22.64" />
-		<PackageReference Include="G4.Plugins" Version="2026.4.22.64" />
-		<PackageReference Include="G4.Plugins.Common" Version="2026.4.22.127" />
-		<PackageReference Include="G4.Plugins.Google" Version="2026.4.22.127" />
-		<PackageReference Include="G4.Plugins.Ui" Version="2026.4.22.127" />
+		<PackageReference Include="G4.Cache" Version="2026.4.29.65" />
+		<PackageReference Include="G4.CredentialsManager" Version="2026.4.29.65" />
+		<PackageReference Include="G4.Plugins" Version="2026.4.29.65" />
+		<PackageReference Include="G4.Plugins.Common" Version="2026.4.30.128" />
+		<PackageReference Include="G4.Plugins.Google" Version="2026.4.30.128" />
+		<PackageReference Include="G4.Plugins.Ui" Version="2026.4.30.128" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -33,9 +33,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.7" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
 		<PackageReference Include="coverlet.collector" Version="10.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -33,9 +33,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.7" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
 		<PackageReference Include="coverlet.collector" Version="10.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updated G4.Api.csproj to use newer versions of G4.* packages. Upgraded test dependencies (Microsoft.NET.Test.Sdk, MSTest) in both G4.IntegrationTests.csproj and G4.UnitTests.csproj.