### PR TITLE
Remove Description property from models and update tests

### DIFF
--- a/src/G4.Api/Clients/AutomationAsyncClient.cs
+++ b/src/G4.Api/Clients/AutomationAsyncClient.cs
@@ -306,7 +306,6 @@ namespace G4.Api.Clients
 
                 // Update the progress status with details from the automation.
                 queueModel.ProgressStatus.GroupId = queueModel.Automation.GroupId;
-                queueModel.ProgressStatus.Description = queueModel.Automation.Reference.Description;
                 queueModel.ProgressStatus.Iteration = i;
                 queueModel.ProgressStatus.Name = queueModel.Automation.Reference.Name;
                 queueModel.ProgressStatus.Id = $"{queueModel.Automation.Reference.Id}";

--- a/src/G4.Api/Extensions/LocalExtensions.cs
+++ b/src/G4.Api/Extensions/LocalExtensions.cs
@@ -279,7 +279,6 @@ namespace G4.Extensions
                 stageStatus.JobsStatus[jobId] = new G4AutomationStatusModel.JobStatusModel
                 {
                     CompletedRules = 0,
-                    Description = args.Stage.Description,
                     Name = args.Stage.Name,
                     PendingRules = rules,
                     Progress = 0,
@@ -330,7 +329,6 @@ namespace G4.Extensions
                 {
                     CompletedJobs = 0,
                     CompletedRules = 0,
-                    Description = args.Stage.Description,
                     JobsStatus = jobsStatus,
                     Name = args.Stage.Name,
                     PendingJobs = jobs,
@@ -381,7 +379,6 @@ namespace G4.Extensions
                         CompletedJobs = 0,
                         CompletedRules = 0,
                         CompletedStages = 0,
-                        Description = automationReference.Description,
                         Name = automationReference.Name,
                         PendingJobs = jobs,
                         PendingRules = rules,

--- a/src/G4.Api/G4.Api.csproj
+++ b/src/G4.Api/G4.Api.csproj
@@ -30,12 +30,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Cache" Version="2026.4.29.65" />
-		<PackageReference Include="G4.CredentialsManager" Version="2026.4.29.65" />
-		<PackageReference Include="G4.Plugins" Version="2026.4.29.65" />
-		<PackageReference Include="G4.Plugins.Common" Version="2026.4.30.128" />
-		<PackageReference Include="G4.Plugins.Google" Version="2026.4.30.128" />
-		<PackageReference Include="G4.Plugins.Ui" Version="2026.4.30.128" />
+		<PackageReference Include="G4.Cache" Version="2026.6.15.66" />
+		<PackageReference Include="G4.CredentialsManager" Version="2026.6.15.66" />
+		<PackageReference Include="G4.Plugins" Version="2026.6.15.66" />
+		<PackageReference Include="G4.Plugins.Common" Version="2026.6.16.129" />
+		<PackageReference Include="G4.Plugins.Google" Version="2026.6.16.129" />
+		<PackageReference Include="G4.Plugins.Ui" Version="2026.6.16.129" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.IntegrationTests/Framework/TestCaseBase.cs
+++ b/src/G4.IntegrationTests/Framework/TestCaseBase.cs
@@ -45,13 +45,13 @@ namespace G4.IntegrationTests.Framework
             _environments ??= [];
 
             // Parse and set the number of test case attempts
-            _attempts = context.Properties.ContainsKey(key: "Integration.NumberOfAttempts")
-                ? int.Parse($"{context.Properties["Integration.NumberOfAttempts"]}")
+            _attempts = context.Properties.TryGetValue(key: "Integration.NumberOfAttempts", out object numberOfAttempts)
+                ? int.Parse($"{numberOfAttempts}")
                 : int.Parse("1");
 
             // Parse and set the time interval between test case attempts
-            _attemptsDelay= context.Properties.ContainsKey(key: "Integration.AttemptsDelay")
-                ? int.Parse($"{context.Properties["Integration.AttemptsDelay"]}")
+            _attemptsDelay= context.Properties.TryGetValue(key: "Integration.AttemptsDelay", out object attemptsDelay)
+                ? int.Parse($"{attemptsDelay}")
                 : int.Parse("15000");
 
             // Set the application under test from the test context properties
@@ -375,8 +375,7 @@ namespace G4.IntegrationTests.Framework
                             {
                                 Reference = new()
                                 {
-                                    Description = "Job responsible for invoking integration a single integration test.",
-                                    Name = $"Invoking Test {testCase.GetType().FullName}",
+                                    Name = $"Invoking Test {testCase.GetType().FullName}"
                                 },
                                 Rules = actionsList
                             }

--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -32,15 +32,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.7" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.9" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.UnitTests/Engine/G4ClientEventsTests.cs
+++ b/src/G4.UnitTests/Engine/G4ClientEventsTests.cs
@@ -120,8 +120,7 @@ namespace G4.UnitTests.Engine
             {
                 Reference = new()
                 {
-                    Name = TestBase.NewRandomString(5),
-                    Description = TestBase.NewRandomString(5),
+                    Name = TestBase.NewRandomString(5)
                 },
                 Rules = NewLoginRules()
             };
@@ -131,8 +130,7 @@ namespace G4.UnitTests.Engine
             {
                 Reference = new()
                 {
-                    Name = TestBase.NewRandomString(5),
-                    Description = TestBase.NewRandomString(5),
+                    Name = TestBase.NewRandomString(5)
                 },
                 Rules = NewAssertionRules()
             };

--- a/src/G4.UnitTests/Engine/G4ClientTests.cs
+++ b/src/G4.UnitTests/Engine/G4ClientTests.cs
@@ -38,14 +38,21 @@ namespace G4.UnitTests.Engine
 
             // Retrieve the current templates; expecting no templates initially
             var templates = client.Templates.GetTemplates();
-            Assert.AreEqual(0, templates.Count(), "Expected no templates before adding a new one.");
+            Assert.IsEmpty(
+                collection: templates,
+                message: "Expected no templates before adding a new one."
+            );
 
             // Add a new template based on the manifest loaded from the JSON file
             client.Templates.AddTemplate(manifest);
 
             // Retrieve the templates again after adding the new template; expecting one template now
             templates = client.Templates.GetTemplates();
-            Assert.AreEqual(1, templates.Count(), "Expected one template after adding a new one.");
+            Assert.HasCount(
+                expected: 1,
+                collection: templates,
+                message: "Expected one template after adding a new one."
+            );
 
             // Construct the JSON string for an action rule, including the $type field and the plugin parameters
             var ruleJson = "{" +
@@ -195,7 +202,11 @@ namespace G4.UnitTests.Engine
                 .Exceptions;
 
             // Assert that the count of exceptions in the flat request is 4
-            Assert.AreEqual(4, flatRequest.Count());
+            Assert.HasCount(
+                expected: 4,
+                collection: flatRequest,
+                message: "The count of exceptions in the flat request is not equal to 4."
+            );
         }
 
         [TestMethod(DisplayName = "Verify the count of performance points in the flat request when data is provided")]
@@ -219,7 +230,11 @@ namespace G4.UnitTests.Engine
                 .PerformancePoints;
 
             // Assert that the count of performance points in the flat request is 48
-            Assert.AreEqual(48, flatRequest.Count());
+            Assert.HasCount(
+                expected: 48,
+                collection: flatRequest,
+                message: "The count of performance points in the flat request is not equal to 48."
+            );
         }
 
         [TestMethod(DisplayName = "Verify the response size of the flat request when data is provided")]
@@ -333,9 +348,6 @@ namespace G4.UnitTests.Engine
             // Assert that the reference is not null
             Assert.IsNotNull(value: reference, message: "Reference must not be null.");
 
-            // Assert that the reference's Description is not null or empty
-            Assert.IsFalse(condition: string.IsNullOrEmpty(reference.Description), message: "Reference description must not be null or empty.");
-
             // Assert that the reference's Name is not null or empty
             Assert.IsFalse(condition: string.IsNullOrEmpty(reference.Name), message: "Reference name must not be null or empty.");
 
@@ -437,9 +449,6 @@ namespace G4.UnitTests.Engine
             // Assert that the reference is not null
             Assert.IsNotNull(value: reference, message: "Reference must not be null.");
 
-            // Assert that the reference's Description is not null or empty
-            Assert.IsFalse(condition: string.IsNullOrEmpty(reference.Description), message: "Reference description must not be null or empty.");
-
             // Assert that the reference's Name is not null or empty
             Assert.IsFalse(condition: string.IsNullOrEmpty(reference.Name), message: "Reference name must not be null or empty.");
 
@@ -476,14 +485,6 @@ namespace G4.UnitTests.Engine
                 .First())
                 .Reference;
 
-            // Get the summary from the SendKeys plugin manifest and join it with a
-            // newline character to form a string summary of the plugin manifest for
-            // comparison with the reference's description property later on in the test method
-            var summary = string
-                .Join('\n', new SendKeys(pluginSetup: default).GetManifest().Summary)
-                .Replace("\n", string.Empty)
-                .Replace("  ", " ");
-
             // Default guid pattern for matching the reference's id property with the default guid format
             const string guidPattern = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
 
@@ -492,12 +493,6 @@ namespace G4.UnitTests.Engine
 
             // Assert the reference's Alias is 'SendKeys'
             Assert.AreEqual(expected: "SendKeys", actual: reference.Alias, "Reference alias must be 'SendKeys'.");
-
-            // Assert that the reference's description match the manifest summary
-            Assert.AreEqual(
-                expected: summary,
-                actual: reference.Description.Replace("  ", " "),
-                message: "Reference description must match the manifest summary.");
 
             // Assert that the reference's name is 'SendKeys'
             Assert.AreEqual(expected: "SendKeys", actual: reference.Name, message: "Reference name must be 'SendKeys'.");
@@ -547,9 +542,6 @@ namespace G4.UnitTests.Engine
 
             // Asseret that AutomationReference is not null
             Assert.IsNotNull(value: reference.AutomationReference, message: "Automation reference must not be null.");
-
-            // Assert that the reference's Description is not null or empty
-            Assert.IsFalse(condition: string.IsNullOrEmpty(reference.Description), message: "Reference description must not be null or empty.");
 
             // Assert that the reference's Name is not null or empty
             Assert.IsFalse(condition: string.IsNullOrEmpty(reference.Name), message: "Reference name must not be null or empty.");
@@ -628,7 +620,11 @@ namespace G4.UnitTests.Engine
                 .SelectMany(i => i.ResponseData.Exceptions);
 
             // Assert that the count of exceptions in the flattened collection is 12
-            Assert.AreEqual(12, exceptions.Count());
+            Assert.HasCount(
+                expected: 12,
+                collection: exceptions,
+                message: "The count of exceptions in the flattened collection is not equal to 12."
+            );
         }
 
         [RetryableTestMethod(
@@ -647,7 +643,11 @@ namespace G4.UnitTests.Engine
             var session = client.Automation.Invoke(automation).First().Value.Sessions.First().Value;
 
             // Assert that the count of exceptions in the session's flat request is 4
-            Assert.AreEqual(4, session.ResponseData.Exceptions.Count());
+            Assert.HasCount(
+                expected: 4,
+                collection: session.ResponseData.Exceptions,
+                message: "The count of exceptions in the session's flat request is not equal to 4."
+            );
         }
 
         [TestMethod(DisplayName = "Verify the count of performance points in the sessions when data is provided")]
@@ -668,7 +668,11 @@ namespace G4.UnitTests.Engine
                 .SelectMany(i => i.ResponseData.PerformancePoints);
 
             // Assert that the count of performance points in the flattened collection is 144
-            Assert.AreEqual(144, performancePoints.Count());
+            Assert.HasCount(
+                expected: 144,
+                collection: performancePoints,
+                message: "The count of performance points in the flattened collection is not equal to 144."
+            );
         }
 
         [TestMethod(DisplayName = "Verify the count of performance points in the sessions when no data is provided")]
@@ -689,7 +693,11 @@ namespace G4.UnitTests.Engine
                 .SelectMany(i => i.ResponseData.PerformancePoints);
 
             // Assert that the count of performance points in the flattened collection is 48
-            Assert.AreEqual(48, performancePoints.Count());
+            Assert.HasCount(
+                expected: 48,
+                collection: performancePoints,
+                message: "The count of performance points in the flattened collection is not equal to 48."
+            );
         }
 
         [RetryableTestMethod(
@@ -773,7 +781,11 @@ namespace G4.UnitTests.Engine
             // Assert that each stage in the structured request has 2 jobs
             foreach (var stage in stages)
             {
-                Assert.AreEqual(2, stage.Jobs.Count());
+                Assert.HasCount(
+                    expected: 2,
+                    collection: stage.Jobs,
+                    message: "The count of jobs in the stage is not equal to 2."
+                );
             }
         }
 
@@ -844,9 +856,6 @@ namespace G4.UnitTests.Engine
                 // Assert that the reference is not null
                 Assert.IsNotNull(reference, "Reference must not be null.");
 
-                // Assert that the reference's Description is not null or empty
-                Assert.IsFalse(string.IsNullOrEmpty(reference.Description), "Reference description must not be null or empty.");
-
                 // Assert that the reference's Name is not null or empty
                 Assert.IsFalse(string.IsNullOrEmpty(reference.Name), "Reference name must not be null or empty.");
 
@@ -878,7 +887,11 @@ namespace G4.UnitTests.Engine
                 .Stages;
 
             // Assert that the count of stages in the structured request is 4
-            Assert.AreEqual(4, stages.Count());
+            Assert.HasCount(
+                expected: 4,
+                collection: stages,
+                message: "The count of stages in the structured request is not equal to 4."
+            );
         }
 
         [TestMethod(DisplayName = "Verify the stage details of a stage in the structured request when data is provided")]
@@ -912,14 +925,15 @@ namespace G4.UnitTests.Engine
                 // Assert that the stage's name is not null or empty
                 Assert.IsFalse(string.IsNullOrEmpty(stage.Name), "Stage name must not be null or empty.");
 
-                // Assert that the stage's description is not null or empty
-                Assert.IsFalse(string.IsNullOrEmpty(stage.Description), "Stage description must not be null or empty.");
-
                 // Assert that the reference's Id matches the default guid format (00000000-0000-0000-0000-000000000000)
                 Assert.IsTrue(condition: Regex.IsMatch(stage.Id, guidPattern), message: "Reference id must match the default guid format.");
 
                 // Assert that the stage's jobs count is 2
-                Assert.AreEqual(2, stage.Jobs.Count());
+                Assert.HasCount(
+                    expected: 2,
+                    collection: stage.Jobs,
+                    message: "The count of jobs in the stage is not equal to 2."
+                );
             }
         }
 
@@ -949,19 +963,15 @@ namespace G4.UnitTests.Engine
             foreach (var stage in stages)
             {
                 // Assert that the stage's jobs count is 2
-               Assert.AreEqual(
-                   expected: 2,
-                   actual: stage.Jobs.Count(),
-                   message: "The count of jobs in the stage is not equal to 2.");
+                Assert.HasCount(
+                    expected: 2,
+                    collection:
+                    stage.Jobs, message: "The count of jobs in the stage is not equal to 2."
+                );
 
                 // Assert that the job details of each job in the stage are correct
                 foreach (var job in stage.Jobs)
                 {
-                    // Assert that the job's description is not null or empty
-                    Assert.IsFalse(
-                        condition: string.IsNullOrEmpty(job.Description),
-                        message: "Job description must not be null or empty.");
-
                     // Assert that the job's id is not null or empty
                     Assert.IsFalse(condition: string.IsNullOrEmpty(job.Id), message: "Job id must not be null or empty.");
 

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -32,16 +32,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.7" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
-		<PackageReference Include="coverlet.collector" Version="10.0.0">
+		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.9" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Removed the Description property from automation, job, and stage models, and updated all related initializations and assertions in main code and tests. Upgraded package references to latest versions. Improved property retrieval in TestCaseBase.cs and replaced collection count assertions with Assert.HasCount/IsEmpty for clarity.