### PR TITLE
Update NuGet package versions in project files

### DIFF
--- a/src/G4.Api/G4.Api.csproj
+++ b/src/G4.Api/G4.Api.csproj
@@ -30,12 +30,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Cache" Version="2026.6.15.66" />
-		<PackageReference Include="G4.CredentialsManager" Version="2026.6.15.66" />
-		<PackageReference Include="G4.Plugins" Version="2026.6.15.66" />
-		<PackageReference Include="G4.Plugins.Common" Version="2026.6.16.129" />
-		<PackageReference Include="G4.Plugins.Google" Version="2026.6.16.129" />
-		<PackageReference Include="G4.Plugins.Ui" Version="2026.6.16.129" />
+		<PackageReference Include="G4.Cache" Version="2026.6.23.69" />
+		<PackageReference Include="G4.CredentialsManager" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Plugins" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Plugins.Common" Version="2026.6.23.131" />
+		<PackageReference Include="G4.Plugins.Google" Version="2026.6.23.131" />
+		<PackageReference Include="G4.Plugins.Ui" Version="2026.6.23.131" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -33,14 +33,14 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.9" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
 		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -33,14 +33,14 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.9" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
 		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
 	</ItemGroup>
 


### PR DESCRIPTION
Upgraded G4.* packages in G4.Api.csproj to 2026.6.23.x. Updated Microsoft.NET.Test.Sdk to 18.7.0 and Swashbuckle.AspNetCore to 10.2.3 in both test projects. No other changes made.